### PR TITLE
Fix for Error executing steps 3 and 4 of CodeCommit Repository Preparation

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ ssh-keygen -t rsa -b 4096 -C "your_email@example.com" -f ${BASE_PATH}/automatic-
     cd ${BASE_PATH}
     cp -r ${BASE_PATH}/apps/my-amazing-application/* my-amazing-application/
     cd my-amazing-application/
+    git branch -m master main
     git add .
     git commit -m "Initial Commit"
     git push origin main
@@ -102,6 +103,7 @@ ssh-keygen -t rsa -b 4096 -C "your_email@example.com" -f ${BASE_PATH}/automatic-
     cd $BASE_PATH
     cp -r ${BASE_PATH}/apps/my-awesome-application/* my-awesome-application/
     cd my-awesome-application/
+    git branch -m master main
     git add .
     git commit -m "Initial Commit"
     git push origin main
@@ -171,3 +173,31 @@ docker push ${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/my-amazing-applica
 6. **CodeCommit PRs**  
    Inspect the CodeCommit `my-amazing-application` repository for generated pull requests.
 ![PRResult](static/pr-result.png)
+
+## Clean up
+
+When you're finished, you can remove the infrastructure created to limit recurring charges by running the following commands:
+
+1. Empty the ECR repositories
+
+    ```bash
+    
+    repositories=("automatic-pr-bedrock" "my-amazing-application")
+    
+    for repository_name in "${repositories[@]}"; do
+      echo "Emptying repository: $repository_name"
+    
+      image_digests=$(aws ecr list-images --repository-name $repository_name --query 'imageIds[].imageDigest' --output text)
+    
+      for image_digest in $image_digests; do
+        echo "Deleting image with digest: $image_digest"
+        aws ecr batch-delete-image --repository-name $repository_name --image-ids imageDigest=$image_digest
+      done
+    done
+    ```
+
+2. Delete the Terraform configuration
+    ```bash
+    cd ${BASE_PATH}/terraform/
+    terraform destroy
+    ```

--- a/README.md
+++ b/README.md
@@ -190,7 +190,6 @@ When you're finished, you can remove the infrastructure created to limit recurri
       image_digests=$(aws ecr list-images --repository-name $repository_name --query 'imageIds[].imageDigest' --output text)
     
       for image_digest in $image_digests; do
-        echo "Deleting image with digest: $image_digest"
         aws ecr batch-delete-image --repository-name $repository_name --image-ids imageDigest=$image_digest
       done
     done

--- a/terraform/apps.tf
+++ b/terraform/apps.tf
@@ -71,6 +71,7 @@ resource "aws_ecr_repository" "automatic_pr_bedrock" {
 resource "aws_codecommit_repository" "my_amazing_application_repo" {
   repository_name = "my-amazing-application"
   description     = "Repository for My Amazing Application"
+  default_branch  = "main"
 
   tags = {
     Name = "My Amazing Application Repo"
@@ -80,6 +81,7 @@ resource "aws_codecommit_repository" "my_amazing_application_repo" {
 resource "aws_codecommit_repository" "my_awesome_application_repo" {
   repository_name = "my-awesome-application"
   description     = "Repository for My Awesome Application"
+  default_branch  = "main"
 
   tags = {
     Name = "My Awesome Application Repo"


### PR DESCRIPTION
*Issue #, if available:* [13](https://github.com/aws-samples/gen-ai-cve-patching/issues/13)

*Description of changes:* Fix for Error executing steps 3 and 4 of CodeCommit Repository Preparation

- Setting default_branch parameter for terraform.aws_codecommit_repository to main
- Updated readme to change branch name to main
- Added cleanup instructions in readme


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
